### PR TITLE
部員募集ページの負の遺産の削除とArticleページの更新

### DIFF
--- a/_articles/markdowns/2023/welcome-wn.md
+++ b/_articles/markdowns/2023/welcome-wn.md
@@ -4,30 +4,6 @@ date: '2023-01-30'
 caption: '新入部員募集ページを公開しました'
 ---
 
-<!-- ちょっと無理がある -->
-<style>
-  pre {
-    display: block;
-    width: 100%;
-    height: 100%;
-    font: inherit;
-  }
-  code {
-    display: block;
-    width: 100%;
-    height: 100%;
-    border-left: 2px solid lightgray;
-    padding-left: 8px;
-    font: inherit;
-  }
-  blockquote {
-    margin: 0.5em 0;
-    transform: translateY(-0.5em);
-    border: none !important;
-    color: gray;
-  }
-</style>
-
 ## 新入部員募集概要
 
 応用数学研究部に興味をお寄せいただきありがとうございます！

--- a/_pages/markdowns/archive.md
+++ b/_pages/markdowns/archive.md
@@ -13,6 +13,13 @@ title: 'アーカイブ'
 - [コンタクト](/contact)
 - [FAQ](/faq)
 
+## 2022 年度
+
+- [春期新歓](/articles/2022/welcome-sp)
+- [春期講義班紹介](/articles/2022/lecture-sp)
+- [秋期新歓](/articles/2022/welcome-au)
+- [秋期講義班紹介](/articles/2022/lecture-au)
+
 ## 2021 年度
 
 - [春期新歓](/articles/2021/welcome)


### PR DESCRIPTION
もう新しい体制になってるのにすみません。

2023 年度の部員募集ページに引き継がれていた 2022 年度のこの部分

```html
<!-- ちょっと無理がある -->
<style>
  pre {
    display: block;
    width: 100%;
    height: 100%;
    font: inherit;
  }
  code {
    display: block;
    width: 100%;
    height: 100%;
    border-left: 2px solid lightgray;
    padding-left: 8px;
    font: inherit;
  }
  blockquote {
    margin: 0.5em 0;
    transform: translateY(-0.5em);
    border: none !important;
    color: gray;
  }
</style>
```

なのですが、これは

<img width="480" alt="スクリーンショット 2023-02-11 15 17 39" src="https://user-images.githubusercontent.com/70136871/218244219-b84f16c2-4bf4-48ed-95e5-92a63ce95311.png">

を表現するための CSS です (コードブロックは pre と code、引用は blockquote で、本来の意味と違うタグの使い方をしてしまっています)。

oskt.us 本体に手を入れたくはないけど見た目を整えたかったので、本来の意味と違うタグの使い方 & CSS ベタ書きで対応してました。  
あまりいい実装ではない (ごめん) のと、新しい 2023 年度の新歓ページではコードブロックも引用も使っていないようなので、削除して大丈夫です。

ついでなので Article ページに 2022 年度分を追加しました。